### PR TITLE
add the ability to overide the error handler and supporting retry

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
  * Thrown error handling methos, when any part of the stream throws an error
  * it pass its error to this method, with retry function and the thrown error
  * this function decides if this error is retryable, and then retry the method
- * that generated the error by colling to retry, otherwise it emmits error.
+ * that generated the error by calling to retry, otherwise it emmits error.
  *
  * Overide this method to create your own error handling and retrying mechanism
  * 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,6 @@ function FacebookInsightStream( options ) {
 
     options.edge = EDGEMAP[ options.node ];
     this.options = options;
-    console.log( options.itemList )
-
 }
 
 // _read will be called once for each collected item

--- a/index.js
+++ b/index.js
@@ -25,12 +25,13 @@ var EDGEMAP = {
 util.inherits( FacebookInsightStream, stream.Readable )
 function FacebookInsightStream( options ) {
     stream.Readable.call( this, { objectMode: true } );
-    var isFunction = typeof options.itemList === 'function';
+    var listItems = options.itemlist;
+    var isFunction = typeof listItems === 'function';
     if ( !isFunction ) {
-        var itemList = options.itemList;
-        options.itemList = function () { return itemList }
+        listItems = function () { return options.itemList }
     }
 
+    options.listItems = listItems
     options.edge = EDGEMAP[ options.node ];
     this.options = options;
 }
@@ -116,7 +117,7 @@ FacebookInsightStream.prototype._init = function ( callback ) {
 
     // options.itemlist is a function that can return either array of items or
     // or a promise that resolved with array of items
-    var itemList = options.itemList();
+    var itemList = options.listItems();
     return Promise.resolve( itemList )
         .bind( this )
         .map( this._initItem, { concurrency: 3 } )

--- a/package.json
+++ b/package.json
@@ -22,5 +22,12 @@
   "homepage": "https://github.com/panoplyio/facebook-insight-stream#readme",
   "devDependencies": {
     "mocha": "^2.3.4"
+  },
+  "dependencies": {
+    "bluebird": "^3.4.1",
+    "extend": "^3.0.0",
+    "request": "^2.74.0",
+    "sugar": "1.4.1",
+    "util": "^0.10.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -24,12 +24,31 @@ describe( "error", function () {
     })
 })
 
+describe( "retry", function () {
+    var result = {};
+    var source = {
+        apps: [ 'myApp' ],
+    }
+    var _err = { message: 'retryError' };
+    var response = { "myApp": { error: _err, name: "myApp", data: dataGenerator( 1, null ) } }
+
+    before( initialize( result, response, source ) )
+    after( reset )
+
+    it( 'retry after specified error', function () {
+        var dataSize = Object.keys( result.data[ 0 ] ).length;
+        // the data size should be as the size of metrics + 3 columns ( date, name, id )
+        assert.equal( dataSize, METRICS.length + 3 );
+        assert.equal( result.data.length, 1 )
+    })
+})
+
 describe( "progress", function () {
     var result = {};
     var source = { 
         apps: [ "myApp" ],
     };
-    var response = { "myApp": dataGenerator( 1, null, "myApp" ) }
+    var response = { "myApp": { data: dataGenerator( 1, null ), name: "myApp" } }
 
     before( initialize( result, response, source ) )
     after( reset )
@@ -48,7 +67,7 @@ describe( "empty metric", function () {
         apps: [ "myApp" ],
     }
 
-    var response = { "myApp": dataGenerator( 1, "api_calls", "myApp" ) }
+    var response = { "myApp": { data: dataGenerator( 1, "api_calls" ), name: "myApp" } }
 
     before( initialize( result, response, source ) )
     after( reset )
@@ -68,7 +87,7 @@ describe( "appName and appId", function () {
         apps: [ "someId" ],
     }
 
-    var response = { "someId": dataGenerator( 1, null, "myApp" ) }
+    var response = { "someId": { data: dataGenerator( 1, null ), name: "myApp" } }
 
     before( initialize( result, response, source ) )
     after( reset )
@@ -88,8 +107,8 @@ describe( "collect", function () {
     }
 
     var response = { 
-        "myApp1": dataGenerator( 100, null, "myApp1" ),
-        "myApp2": dataGenerator( 100, null, "myApp2" )
+        "myApp1": { data: dataGenerator( 100, null ), name: "myApp1" },
+        "myApp2": { data: dataGenerator( 100, null ), name: "myApp2" }
     }
 
     before( initialize( result, response, source ) )
@@ -97,8 +116,8 @@ describe( "collect", function () {
 
     it( "should read 200 rows for two apps", function() {
         assert.equal( result.data.length, 200 );
-        assert.equal( result.data[ 0 ].appName, "myApp1" );
-        assert.equal( result.data[ 100 ].appName, "myApp2" );
+        assert.equal( result.data[ 0 ].appName, "myApp2" );
+        assert.equal( result.data[ 100 ].appName, "myApp1" );
     })
 })
 
@@ -114,18 +133,24 @@ function initialize( result, response, source ) {
             url = url.split( BASEURL )[ 1 ];
             var params = url.split( "?" )[ 0 ].split( "/" );
             var app = params[ 1 ];
-            var metric = params[ 3 ]; 
-            var res = response[ app ];
+            var metric = params[ 3 ];
+            var appData = response[ app ].data;
+            var appName = response[ app ].name;
+            var appError = response[ app ].error;
+            var res;
 
             //we are in the get apps request
             if ( app == "me" ) {
-                res = { data: res }
+                res = { data: response[ app ] }
             }
             // if there is no metric, we are in the first request so returning the name
             else if ( ! metric ) {
-                res = { name: res.name };
+                res = { name: appName };
+            } else if ( appError ) {
+                res = { error: appError };
+                response[ app ].error = null; 
             } else {
-                res.error || ( res = { data: res[ metric ] } ) 
+                res = { data: appData[ metric ] }
             }
 
             res = JSON.stringify( res )
@@ -139,6 +164,14 @@ function initialize( result, response, source ) {
             period: "daily",
             metrics: METRICS,
             itemList: source.apps
+        }
+
+        FacebookInsightStream.prototype.handleError = function ( error, retry ) {
+            if ( error.message === 'retryError' ) {
+                return retry()
+            } else {
+                this.emit( 'error', error );
+            }
         }
 
         var testStream = new FacebookInsightStream( options )
@@ -170,7 +203,7 @@ function dataGenerator ( size, emptyMetric, name ) {
     METRICS.forEach( function ( metric ) {
         var values = [];
 
-        for ( var i = 0; i < size; i++ ) {
+        for ( var i = 1; i <= size; i++ ) {
             values.push( {
                 //nuiqe date for each row
                 end_time: "some_date-" + i ,

--- a/test.js
+++ b/test.js
@@ -180,7 +180,7 @@ function initialize( result, response, source ) {
             result.data = result.data.concat( chunk )
         })
         .on( "error", function ( error ) {
-            result.error = error;
+            result.error || ( result.error = error );
             done();
             done = function () {};
         })


### PR DESCRIPTION
@liorrozen @alonweissfeld Hey guys, we are having an error in facebook posts the require implementing a backoff and retry mechanism, so i have preformed some change to this module so it will allow to any other stream that extend it, to have its own error handling with the ability to preform simple retry without getting into the implementation level itself.

Also, apparently that package.json was missing the relevant dependencies for this module. It worked for us because we required the same dependencies in our base code, but still it should include those dependencies.

Thanks 