### PR TITLE
Individual tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var options = {
     token: "Replace with your facebook access token",
     period: "day",
     metrics: ["page_views"],
-    itemList: ["replace with your facebook page id"],
+    itemList: [{id: page_id, token: page_token}],
 }
 
 var pageStream = new FacebookInsightStream( options )

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
-// doc: this module is a facebook-insights read stream built over node readable stream
-// it provide stream api to read insights data from facebook accounts,
+// doc: this module is a facebook-insights read stream built over node readable
+// stream. It provide stream api to read insights data from facebook accounts,
 // currently supporting only pages-insight, posts-insights and app-insights.
 
 module.exports = FacebookInsightStream;
 
-var util = require( "util" );
-var sugar = require( "sugar" );
-var stream = require( "stream" );
-var extend = require( "extend" );
-var request = require( "request" );
-var Promise = require( "bluebird" );
+var util = require( 'util' );
+var sugar = require( 'sugar' );
+var stream = require( 'stream' );
+var extend = require( 'extend' );
+var request = require( 'request' );
+var Promise = require( 'bluebird' );
 const queryString = require('query-string')
 
 request = Promise.promisifyAll( request )
 
-var BASEURL = "https://graph.facebook.com/v2.10";
+var BASEURL = 'https://graph.facebook.com/v2.10';
 // Missing data is flagged by the error code 100
 // GraphMethodException error:
 // Object with ID 'some_id' does not exist,
@@ -25,9 +25,9 @@ var NOT_SUPPORTED_CODE = 3001;
 
 //edge url for each node type
 var EDGEMAP = {
-    page: "insights",
-    app: "app_insights",
-    post: "insights"
+    page: 'insights',
+    app: 'app_insights',
+    post: 'insights'
 }
 
 util.inherits( FacebookInsightStream, stream.Readable )
@@ -86,10 +86,10 @@ FacebookInsightStream.prototype._init = function ( callback ) {
 
     var path = [
         BASEURL,
-        "{id}",
+        '{id}',
         options.edge,
-        "{metric}",
-    ].join( "/" )
+        '{metric}',
+    ].join( '/' )
 
     var hasEvents = options.events && options.events.length;
     var breakdowns = options.breakdowns;
@@ -105,7 +105,7 @@ FacebookInsightStream.prototype._init = function ( callback ) {
 
     if ( breakdowns && breakdowns.length ) {
         for ( var i = 0; i < breakdowns.length; i += 1 ) {
-            query += "&breakdowns[{index}]={breakdown}".assign( {
+            query += '&breakdowns[{index}]={breakdown}'.assign( {
                 index: i,
                 breakdown: breakdowns[ i ]
             });
@@ -115,7 +115,7 @@ FacebookInsightStream.prototype._init = function ( callback ) {
     // this url is urlPattern shared by all the requests
     // each request using thie pattern should replace the
     // {id} and {metric} place holders with real values
-    this.url = [ path, query ].join( "?" )
+    this.url = [ path, query ].join( '?' )
 
     // options.itemlist is a function that can return either array of items or
     // or a promise that resolved with array of items
@@ -149,9 +149,9 @@ FacebookInsightStream.prototype._initItem = function ( item ) {
         token: item.token || options.token
     };
 
-    var url = strReplace( "{base}/{id}?access_token={token}", model )
+    var url = strReplace( '{base}/{id}?access_token={token}', model )
 
-    var title = "FACEBOOK " + options.node.toUpperCase();
+    var title = 'FACEBOOK ' + options.node.toUpperCase();
     console.log( new Date().toISOString(), title, url )
 
     return FacebookInsightStream._apiCall(url)
@@ -171,7 +171,7 @@ FacebookInsightStream.prototype._initItem = function ( item ) {
             return result
         })
         .catch( SkippedError, function ( error ) {
-            console.warn( "facebook-insights skipped error", error );
+            console.warn( 'facebook-insights skipped error', error );
         })
         .catch( function ( error ) {
             var retry = this._initItem.bind( this, item );
@@ -197,9 +197,9 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
 
             // if the key is constructed with numerous attributes,
             // take the datetime information
-            row.date = key.split( "__" )[ 0 ];
-            row[ options.node + "Id" ] = item.id;
-            row[ options.node + "Name" ] = item.name;
+            row.date = key.split( '__' )[ 0 ];
+            row[ options.node + 'Id' ] = item.id;
+            row[ options.node + 'Name' ] = item.name;
             // set created_time for posts
             if ( options.node === 'post' ) {
                 row[ 'created_time' ] = item.createdTime;
@@ -207,10 +207,10 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
             return row;
         })
 
-        this.emit( "progress", {
+        this.emit( 'progress', {
             total: this.total,
             loaded: ++this.loaded,
-            message: "{{remaining}} " + options.node + "s remaining"
+            message: '{{remaining}} ' + options.node + 's remaining'
         })
         return data;
     }
@@ -233,19 +233,19 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
 
     var url = this.url + '&access_token=' + item.token
     url = strReplace( url, model );
-    var title = "FACEBOOK " + options.node.toUpperCase();
+    var title = 'FACEBOOK ' + options.node.toUpperCase();
 
     return FacebookInsightStream._apiCall(url)
         .get( 1 )
         .then( JSON.parse )
         .then( errorHandler.bind( null, options ) )
-        .get( "data" )
+        .get( 'data' )
         .bind( this )
         .then( function ( data ) {
             // in case that there is no data for a given metric
             // we will skip to the next metric
             if ( ! data.length ) {
-                var error = new Error( "No data found for the metric " + _metric );
+                var error = new Error( 'No data found for the metric ' + _metric );
                 error.skip = true;
                 throw error;
             }
@@ -260,7 +260,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
             // keys for the buffer by the date and different breakdowns
             // we're using the '__' to later seperate the date
             Object.keys( val.breakdowns || {} ).forEach( function ( b ){
-                key += "__{breakdown}".assign( {
+                key += '__{breakdown}'.assign( {
                     breakdown: val.breakdowns[ b ]
                 });
             });
@@ -293,7 +293,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
             }
         })
         .catch( SkippedError, function ( error ) {
-            console.warn( "facebook-insights skipped error", error );
+            console.warn( 'facebook-insights skipped error', error );
         })
         .then( function () {
             // remove the current paramater when done
@@ -359,19 +359,19 @@ function errorHandler ( options, body )  {
 
 function strReplace ( string, model ) {
     Object.keys( model ).each( function ( name ) {
-        string = string.replace( "{" + name + "}", model[ name ] );
+        string = string.replace( '{' + name + '}', model[ name ] );
     })
 
     return string;
 }
 
 function aggregationType ( ev ) {
-    var events = [ "fb_ad_network_imp", "fb_ad_network_click" ];
+    var events = [ 'fb_ad_network_imp', 'fb_ad_network_click' ];
 
     var shouldUseCount = ev && events.indexOf( ev ) > -1;
     if ( shouldUseCount ) {
-        return "COUNT"
+        return 'COUNT'
     }
 
-    return "SUM";
+    return 'SUM';
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var stream = require( 'stream' );
 var extend = require( 'extend' );
 var request = require( 'request' );
 var Promise = require( 'bluebird' );
-const queryString = require('query-string')
+const queryString = require('querystring')
 
 request = Promise.promisifyAll( request )
 
@@ -228,8 +228,8 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
         extend( model, { ev: _ev, agg: _agg } );
     }
 
-    var url = this.url + '&access_token=' + item.token
-    url = strReplace( url, model );
+    url = url + '&access_token=' + item.token
+    var url = strReplace( this.url, model );
     var title = 'FACEBOOK ' + options.node.toUpperCase();
 
     console.log( new Date().toISOString(), title, url );
@@ -376,6 +376,5 @@ function aggregationType ( ev ) {
     if ( shouldUseCount ) {
         return 'COUNT'
     }
-
     return 'SUM';
 }

--- a/index.js
+++ b/index.js
@@ -105,10 +105,7 @@ FacebookInsightStream.prototype._init = function ( callback ) {
 
     if ( breakdowns && breakdowns.length ) {
         for ( var i = 0; i < breakdowns.length; i += 1 ) {
-            query += '&breakdowns[{index}]={breakdown}'.assign( {
-                index: i,
-                breakdown: breakdowns[ i ]
-            });
+            query += `&breakdowns[${i}]=${breakdowns[i]}`
         }
     }
 
@@ -262,9 +259,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
             // keys for the buffer by the date and different breakdowns
             // we're using the '__' to later seperate the date
             Object.keys( val.breakdowns || {} ).forEach( function ( b ) {
-                key += '__{breakdown}'.assign( {
-                    breakdown: val.breakdowns[ b ]
-                });
+                key += `__${val.breakdowns[b]}`
             });
 
             buffer[ key ] || ( buffer[ key ] = {} )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-insight-stream",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "bluebird": "2.9.32",
     "extend": "3.0.0",
-    "query-string": "^5.0.1",
     "request": "2.53.0",
     "sugar": "1.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sugar": "1.4.1"
   },
   "devDependencies": {
-    "mocha": "2.3.4"
+    "mocha": "2.3.4",
+    "sinon": "4.3.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -177,7 +177,7 @@ describe( "Fetch beginning of time", function () {
     after( reset )
 
     it( 'Fetch insights from beginning of time', function () {
-        assert.equal(calledUrl.includes('&since'), false)
+        assert.equal(calledUrl.includes('since='), false)
     })
 })
 
@@ -194,7 +194,7 @@ describe( "Fetch x Days ago", function () {
     after( reset )
 
     it( 'Fetch insights for past x days', function () {
-        assert.equal(calledUrl.includes('&since'), true)
+        assert.equal(calledUrl.includes('since='), true)
     })
 })
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ var assert = require( "assert" );
 var request = require( "request" );
 var sinon = require( "sinon" );
 var Promise = require( "bluebird" );
+const queryString = require('querystring')
 var FacebookInsightStream = require( "./index" );
 
 var BASEURL = "https://graph.facebook.com/";
@@ -177,7 +178,9 @@ describe( "Fetch beginning of time", function () {
     after( reset )
 
     it( 'Fetch insights from beginning of time', function () {
-        assert.equal(calledUrl.includes('since='), false)
+        const parts = calledUrl.split('?')
+        const parsed = queryString.parse(parts[1])
+        assert.equal(Boolean(parsed.since), false)
     })
 })
 
@@ -194,7 +197,9 @@ describe( "Fetch x Days ago", function () {
     after( reset )
 
     it( 'Fetch insights for past x days', function () {
-        assert.equal(calledUrl.includes('since='), true)
+        const parts = calledUrl.split('?')
+        const parsed = queryString.parse(parts[1])
+        assert.equal(Boolean(parsed.since), true)
     })
 })
 


### PR DESCRIPTION
These changes allow for the stream to use a separate access_token for each entity.
Previously, only one user access token was used but after this PR, each facebook entity is passed as an object and includes it's specific access token.