### PR TITLE
Individual tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ var FacebookInsightStream = require( "facebook-insight-stream" );
 
 var options = {
     pastdays: "30",
-    node: "page",
+    node: "page" OR "post" OR "app",
     token: "Replace with your facebook access token",
     period: "day",
     metrics: ["page_views"],
-    itemList: [{id: page_id, token: page_token}],
+    itemList: 'See comment below'
 }
 
 var pageStream = new FacebookInsightStream( options )
@@ -32,6 +32,18 @@ var pageStream = new FacebookInsightStream( options )
     // progress status  { total: "2", loaded: "1", message: "{{remaining}} pages remain"  }
     .on( "progress", console.log )
 ```
+
+### Item list
+
+The `itemList` parameter can have be passed in two forms:
+
+1. An array of page ids. Eg: `["PAGE_ID1", "PAGE_ID2", "PAGE_ID3"]`.
+    This can be used when fetching nodes of type `post` or `app`.
+2. An array of page objects including id and page access_tokens. Eg:
+    `[{id: "PAGE_ID1", token: "ABC"}, {id: "PAGE_ID2", token: "DEF"}]`
+    When an access_token is passed with each object - it is used for the requests
+    instead of the top level user token.
+    This can be used when fetching nodes of type `page`.
 
 ### FacebookInsightStream options:
 

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ FacebookInsightStream.prototype._initItem = function ( item ) {
     var title = 'FACEBOOK ' + options.node.toUpperCase();
     console.log( new Date().toISOString(), title, url )
 
-    return FacebookInsightStream._apiCall(url)
+    return FacebookInsightStream.apiCall(url)
         .bind( this )
         .get( 1 )
         .then( JSON.parse )
@@ -237,7 +237,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
 
     console.log( new Date().toISOString(), title, url );
 
-    return FacebookInsightStream._apiCall(url)
+    return FacebookInsightStream.apiCall(url)
         .get( 1 )
         .then( JSON.parse )
         .then( errorHandler.bind( null, options ) )
@@ -336,7 +336,7 @@ FacebookInsightStream.prototype.handleError = function ( error, retry ) {
  * @param  {String}  url
  * @returns  {Promise}
  */
-FacebookInsightStream._apiCall = function (url) {
+FacebookInsightStream.apiCall = function (url) {
     return request.getAsync( url )
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-insight-stream",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "facebook",
     "insights"
   ],
-  "author": "Oshri Bienhaker",
+  "author": "Panoply Dev Team",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/panoplyio/facebook-insight-stream/issues"

--- a/test.js
+++ b/test.js
@@ -242,7 +242,7 @@ describe( 'Multiple access tokens', function () {
     it( 'uses item token', function() {
         let token = 'thetoken'
         let calledUrl = null
-        sandbox.stub(FacebookInsightStream, '_apiCall').callsFake(url => {
+        sandbox.stub(FacebookInsightStream, 'apiCall').callsFake(url => {
             calledUrl = url
             return Promise.resolve([null,'{"data":{}}']);
         })


### PR DESCRIPTION
1. Updating the readme to include information about page access tokens.

2. Renamed the `apiCall` function to not have a leading underscore. Leading underscore is usually used to indicate a private function that should not be used by external code but in this case it was.

Major version bump since the API has changed.