### PR TITLE
Compatibility to Audience Network Reporting API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+branches:
+  only:
+    - master
+
+language: node_js
+node_js:
+  - "6.10.1"
+
+# Each step below must succeed for the build to pass
+script:
+    - npm test

--- a/index.js
+++ b/index.js
@@ -363,18 +363,16 @@ function aggregationType ( ev ) {
  */
 function buildGeneralQuery(options) {
     let until = Date.now();
-    let since = new Date();
-    since = since.setDate( since.getDate() - options.pastdays )
-
     // fb ask for timestamp in seconds
     until = Math.round( until / 1000 );
-    since = Math.round( since / 1000 );
+    const pastDays = options.pastdays
+    const since = pastDays ? getSince(pastDays) : ''
 
     const hasEvents = options.events && options.events.length;
     const breakdowns = options.breakdowns;
 
     let queryObj = {
-        since: options.pastdays ? since : '',
+        since: since,
         until: until,
         period: options.period,
         access_token: options.token,
@@ -417,8 +415,9 @@ function buildAudienceQuery(options) {
     let query = 'metrics={metric}&'
     query += buildQueryString(queryObj)
 
-    const breakdowns = options.breakdowns;
+    let breakdowns = options.breakdowns
     if ( breakdowns && breakdowns.length ) {
+        breakdowns = breakdowns.join()
         query += `&breakdowns=${breakdowns}`
     }
 
@@ -434,4 +433,16 @@ function buildQueryString(queryObj) {
     return Object.keys(queryObj).map(key => {
         return `${key}=${queryObj[key]}`
     }).join('&')
+}
+
+/**
+ * Compute the starting limit of the query
+ * @param pastDays
+ * @returns {number}
+ */
+function getSince(pastDays) {
+    let since = new Date();
+    since = since.setDate( since.getDate() - pastDays )
+    // fb ask for timestamp in seconds
+    return Math.round( since / 1000 );
 }

--- a/index.js
+++ b/index.js
@@ -406,10 +406,15 @@ function buildAudienceQuery(options) {
     let queryObj = {
         since: since,
         until: until,
-        period: options.period,
         access_token: options.token,
-        aggregation_period: options.aggregate,
-        limit: options.limit
+    }
+
+    if (options.limit) {
+        queryObj.limit = options.limit
+    }
+
+    if (options.aggregate) {
+        queryObj.aggregation_period = options.aggregate
     }
 
     let query = 'metrics={metric}&'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "NODE_ENV=test node_modules/mocha/bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bluebird": "2.9.32",
     "extend": "3.0.0",
+    "moment": "2.22.2",
     "request": "2.53.0",
     "sugar": "1.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-insight-stream",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -340,9 +340,9 @@ describe( 'API requests', function () {
 
         const expectedURL = [
             `https://graph.facebook.com/v2.12/{id}/adnetworkanalytics`,
-            `?metrics={metric}&since=${since}&until=${until}&period=daily`,
-            `&access_token=someToken&aggregation_period=DAY`,
-            `&limit=someLimit&breakdowns=breakdowns1,breakdowns2`
+            `?metrics={metric}&since=${since}&until=${until}`,
+            `&access_token=someToken&limit=someLimit&aggregation_period=DAY`,
+            `&breakdowns=breakdowns1,breakdowns2`
         ] .join('')
 
         let  _callback = function () {

--- a/test.js
+++ b/test.js
@@ -255,6 +255,54 @@ describe( 'Multiple access tokens', function () {
 
 })
 
+describe( 'Audience API requests', function () {
+    const sandbox = sinon.sandbox.create()
+    const metrics = [
+        'fb_ad_network_request',
+        'fb_ad_network_imp',
+    ]
+    var source = {
+        apps: [{id: 'myApp1', token: 'tok1'}],
+    }
+    const options = {
+        apps: [ 'myApp' ],
+        node: 'audience',
+        pastdays: 7,
+        period: 'daily',
+        metrics: metrics,
+        aggregate: 'DAY',
+        breakdowns: "['placement','country']",
+        itemList: source.apps,
+        limit: 'someLimit',
+        token: 'someToken',
+    }
+    let stream
+    beforeEach(() => {
+        stream = new FacebookInsightStream( options )
+    })
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it( 'build Audience url', function(done) {
+        const startExpected = `https://graph.facebook.com/v2.12/`
+            + `{id}/adnetworkanalytics?metrics={metric}`
+        const endExpected = `access_token=someToken&aggregation_period=DAY&`
+            + `limit=someLimit&breakdowns=['placement','country']`
+        let initItemStub = sandbox.stub(stream, '_initItem').callsFake(item => {
+            return Promise.resolve()
+        })
+
+        let  _callback = function () {
+            assert(stream.url.startsWith(startExpected))
+            assert(stream.url.endsWith(endExpected))
+            done()
+        }
+
+        return stream._init(_callback)
+    })
+})
+
 
 function initialize( result, response, source, fetchBOT ) {
 

--- a/test.js
+++ b/test.js
@@ -276,13 +276,13 @@ describe( 'API requests', function () {
             period: "daily",
             metrics: METRICS,
             itemList: source.apps,
-            ignoreMissing: source.ignoreMissing
+            ignoreMissing: source.ignoreMissing,
+            breakdowns: ['breakdowns1','breakdowns2']
         }
 
-        const stream = new FacebookInsightStream( options )
+        const stream = new FacebookInsightStream(options)
 
-        let initItemStub = sandbox.stub(stream, '_initItem')
-            .callsFake(() => {})
+        sandbox.stub(stream, '_initItem').callsFake(() => {})
 
         let since = new Date()
         since = since.setDate(since.getDate() - options.pastdays)
@@ -295,7 +295,8 @@ describe( 'API requests', function () {
         const expectedURL = [
             `https://graph.facebook.com/v2.12/{id}/app_insights`,
             `/{metric}?since=${since}&until=${until}&period=daily`,
-            `&access_token=undefined&event_name=&aggregateBy=`
+            `&access_token=undefined&event_name=&aggregateBy=`,
+            `&breakdowns[0]=breakdowns1&breakdowns[1]=breakdowns2`
         ] .join('')
 
 
@@ -330,8 +331,7 @@ describe( 'API requests', function () {
 
         const stream = new FacebookInsightStream( options )
 
-        let initItemStub = sandbox.stub(stream, '_initItem')
-            .callsFake(()=> {})
+        sandbox.stub(stream, '_initItem').callsFake(()=> {})
 
         const since = moment().subtract(options.pastdays, 'd')
             .format('YYYY-MM-DD')


### PR DESCRIPTION
[Asana task - Facebook-audience data source: app_event metric is deprecated ](https://app.asana.com/0/346935762552316/747882456628741)

Moving to the current Audience Network reporting API from soon-to-be deprecated API.
