### PR TITLE
Pull more than 90 days

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ FacebookInsightStream.prototype._collect = function ( metrics, item, buffer, eve
 
         extend( model, { ev: _ev, agg: _agg } );
     }
-    
+
     var url = strReplace( this.url, model );
     url = url.replace(/access_token=.*?&/, `access_token=${item.token}&`)
     url = url.replace(/since=.*?&/, `since=${dateRange.since}&`)
@@ -414,11 +414,16 @@ function dateRanges (  n ) {
     let pastdays = n
     let dateRanges = []
     let since = moment().startOf('day');
+    let now = moment().endOf('day')
 
     since = since.subtract(pastdays, 'days')
     while (pastdays > 0) {
         days = (pastdays <= FB_MAX_DATE_RANGE) ? pastdays : FB_MAX_DATE_RANGE 
         until = since.clone().add(days, 'days').endOf('day')
+
+        if (until.isAfter(now)) {
+            until = now.clone()
+        }
             
         dateRanges.push({since: since, until: until})
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-insight-stream",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bluebird": "2.9.32",
     "extend": "3.0.0",
+    "moment": "2.24.0",
     "request": "2.53.0",
     "sugar": "1.4.1"
   },

--- a/test.js
+++ b/test.js
@@ -178,8 +178,10 @@ describe( "Fetch beginning of time", function () {
     after( reset )
 
     it( 'Fetch insights from beginning of time', function () {
+        console.log('calledUrl: ', calledUrl)
         const parts = calledUrl.split('?')
         const parsed = queryString.parse(parts[1])
+        console.log('parsed: ', parsed)
         assert.equal(Boolean(parsed.since), false)
     })
 })
@@ -247,7 +249,7 @@ describe( 'Multiple access tokens', function () {
             return Promise.resolve([null,'{"data":{}}']);
         })
         stream.url = 'https://fb.com/v2.10/123?access_token=&agg=oog&foo=bar'
-        return stream._collect([], {token: token}, {}, [{}])
+        return stream._collect([], {token: token}, {}, [{}], {since: '', until: ''})
             .then(() => {
                 assert(calledUrl.indexOf(token) > -1)
             })

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ var assert = require( "assert" );
 var request = require( "request" );
 var sinon = require( "sinon" );
 var Promise = require( "bluebird" );
+var moment = require('moment')
 const queryString = require('querystring')
 var FacebookInsightStream = require( "./index" );
 
@@ -257,6 +258,83 @@ describe( 'Multiple access tokens', function () {
 
 })
 
+describe('Date Ranges', function () {
+    let clock;
+ 
+
+    beforeEach(function () {
+        //sets date to Mar 31, 2018 at 00:00
+        clock = sinon.useFakeTimers(new Date(2018,2,31).getTime()) 
+    });
+
+    afterEach(function() {
+        clock.restore()
+    })
+    
+    it('Test dateRanges with pastdays 30', function (){
+        let options = {
+            pastdays: '30',
+        }
+        let stream = new FacebookInsightStream( options )
+        let dateRanges = stream.dateRanges
+        
+        let since = moment('2018-03-01').startOf('day')
+        let until = moment('2018-03-31').endOf('day')
+
+        dateRange = dateRanges[0]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+    })
+
+    it('Test dateRanges more than 90 days', function (){
+        let options = {
+            pastdays: '365',
+        }
+        let stream = new FacebookInsightStream( options )
+        let dateRanges = stream.dateRanges
+        
+        let since = moment('2017-03-31').startOf('day')
+        let until = moment('2017-06-29').endOf('day')
+
+        dateRange = dateRanges[0]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+
+        since = moment('2017-06-30').startOf('day')
+        until = moment('2017-09-28').endOf('day')
+
+        dateRange = dateRanges[1]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+
+        since = moment('2017-09-29').startOf('day')
+        until = moment('2017-12-28').endOf('day')
+
+        dateRange = dateRanges[2]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+
+        since = moment('2017-12-29').startOf('day')
+        until = moment('2018-03-29').endOf('day')
+
+        dateRange = dateRanges[3]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+
+        since = moment('2018-03-30').startOf('day')
+        until = moment('2018-03-31').endOf('day')
+
+        dateRange = dateRanges[4]
+
+        assert.equal(dateRange.since, since.unix())
+        assert.equal(dateRange.until, until.unix())
+    })
+})
 
 function initialize( result, response, source, fetchBOT ) {
 


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/854225875551651/845626050566283/f)

Facebook API currently only allows a maximum of 90 days time range per request. This PR split the requests into 3 months chunk if `pastdays` is more than 90 days.