### PR TITLE
Upgrade Facebook Graph API from v3.2 to v3.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var moment = require('moment')
 
 request = Promise.promisifyAll( request )
 
-var BASEURL = 'https://graph.facebook.com/v3.2';
+var BASEURL = 'https://graph.facebook.com/v3.3';
 // Missing data is flagged by the error code 100
 // GraphMethodException error:
 // Object with ID 'some_id' does not exist,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-insight-stream",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Readable stream for reading facebook insights",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[Facebook Marketing API versions prior to V3.3 deprecation](https://app.asana.com/0/711938065542210/1131611914317955/f)

1. Changed Graph API version to v3.3.
2. Changed version of facebook-insight-stream from 4.1.0 to 4.1.1.